### PR TITLE
Add EqRecord module

### DIFF
--- a/src/Data/Record/EqRecord.purs
+++ b/src/Data/Record/EqRecord.purs
@@ -11,7 +11,7 @@ import Data.Symbol (class IsSymbol, SProxy(SProxy))
 import Type.Prelude (class RowToList)
 import Type.Row (kind RowList, Nil, Cons, RLProxy(..))
 
--- | Eq for subrecord given by row list
+-- | Eq for subrecord given by a row list
 class EqRowList (list :: RowList) (row :: # Type) where
   eqRowList :: RLProxy list -> Record row → Record row -> Boolean
 

--- a/src/Data/Record/EqRecord.purs
+++ b/src/Data/Record/EqRecord.purs
@@ -13,7 +13,7 @@ import Type.Row (kind RowList, Nil, Cons, RLProxy(..))
 
 -- | Eq for subrecord given by a row list
 class EqRowList (list :: RowList) (row :: # Type) where
-  eqRowList :: RLProxy list -> Record row → Record row -> Boolean
+  eqRowList :: RLProxy list -> Record row -> Record row -> Boolean
 
 instance _a_eqRowListNil :: EqRowList Nil a where
   eqRowList _ _ _ = true
@@ -25,11 +25,11 @@ instance _b_eqRowListConsRecord ::
   , IsSymbol key
   , RowCons key (Record r) t row) => EqRowList (Cons key (Record r) listRest) row where
   eqRowList _ rec1 rec2 =
-    eqRowList (RLProxy ∷ RLProxy rl) s1 s2
-    && eqRowList (RLProxy ∷ RLProxy listRest) rec1 rec2
+    eqRowList (RLProxy :: RLProxy rl) s1 s2
+    && eqRowList (RLProxy :: RLProxy listRest) rec1 rec2
    where
-    s1 = get (SProxy ∷ SProxy key) rec1
-    s2 = get (SProxy ∷ SProxy key) rec2
+    s1 = get (SProxy :: SProxy key) rec1
+    s2 = get (SProxy :: SProxy key) rec2
 
 instance _c_eqRowListCons ::
   ( Eq a
@@ -37,14 +37,16 @@ instance _c_eqRowListCons ::
   , IsSymbol key
   , RowCons key a r row) => EqRowList (Cons key a listRest) row where
   eqRowList _ rec1 rec2 =
-    get (SProxy ∷ SProxy key) rec1 == get (SProxy ∷ SProxy key) rec2
-    && eqRowList (RLProxy ∷ RLProxy listRest) rec1 rec2
+    get (SProxy :: SProxy key) rec1 == get (SProxy :: SProxy key) rec2
+    && eqRowList (RLProxy :: RLProxy listRest) rec1 rec2
 
 eqRecord
   :: forall row list
    . RowToList row list
   => EqRowList list row
   => Record row
-  → Record row
+  -> Record row
   -> Boolean
-eqRecord rec1 rec2 = eqRowList (RLProxy ∷ RLProxy list) rec1 rec2
+eqRecord rec1 rec2 = eqRowList (RLProxy :: RLProxy list) rec1 rec2
+
+

--- a/src/Data/Record/EqRecord.purs
+++ b/src/Data/Record/EqRecord.purs
@@ -1,0 +1,50 @@
+module Data.Record.EqRecord (
+  class EqRowList
+, eqRowList
+, eqRecord
+) where
+
+import Prelude
+
+import Data.Record (get)
+import Data.Symbol (class IsSymbol, SProxy(SProxy))
+import Type.Prelude (class RowToList)
+import Type.Row (kind RowList, Nil, Cons, RLProxy(..))
+
+-- | Eq for subrecord given by row list
+class EqRowList (list :: RowList) (row :: # Type) where
+  eqRowList :: RLProxy list -> Record row → Record row -> Boolean
+
+instance _a_eqRowListNil :: EqRowList Nil a where
+  eqRowList _ _ _ = true
+
+instance _b_eqRowListConsRecord ::
+  ( EqRowList rl r
+  , RowToList r rl
+  , EqRowList listRest row
+  , IsSymbol key
+  , RowCons key (Record r) t row) => EqRowList (Cons key (Record r) listRest) row where
+  eqRowList _ rec1 rec2 =
+    eqRowList (RLProxy ∷ RLProxy rl) s1 s2
+    && eqRowList (RLProxy ∷ RLProxy listRest) rec1 rec2
+   where
+    s1 = get (SProxy ∷ SProxy key) rec1
+    s2 = get (SProxy ∷ SProxy key) rec2
+
+instance _c_eqRowListCons ::
+  ( Eq a
+  , EqRowList listRest row
+  , IsSymbol key
+  , RowCons key a r row) => EqRowList (Cons key a listRest) row where
+  eqRowList _ rec1 rec2 =
+    get (SProxy ∷ SProxy key) rec1 == get (SProxy ∷ SProxy key) rec2
+    && eqRowList (RLProxy ∷ RLProxy listRest) rec1 rec2
+
+eqRecord
+  :: forall row list
+   . RowToList row list
+  => EqRowList list row
+  => Record row
+  → Record row
+  -> Boolean
+eqRecord rec1 rec2 = eqRowList (RLProxy ∷ RLProxy list) rec1 rec2

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -19,3 +19,7 @@ main = do
   assert $ eqRecord {a: 1, b: "b"} {a: 1, b: "b"}
 
   assert $ eqRecord { a: 1, b: { c : "foo" }} {a: 1, b: { c: "foo" }}
+
+  assert $ not eqRecord {a: 2, b: "b"} {a: 1, b: "b"}
+
+  assert $ not eqRecord { a: 1, b: { c : "foo" }} {a: 1, b: { c: "bar" }}

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,6 +4,7 @@ import Prelude
 
 import Control.Monad.Eff (Eff)
 import Data.Record.ShowRecord (showRecord)
+import Data.Record.EqRecord (eqRecord)
 import Test.Assert (ASSERT, assert)
 
 main :: forall e. Eff (assert :: ASSERT | e) Unit
@@ -14,3 +15,7 @@ main = do
   -- this will produce an Overlapping Instance warning, but work.
   assert $ showRecord { a: 1, b: { c: "foo" } }
            == "{ a: 1, b: { c: \"foo\" } }"
+
+  assert $ eqRecord {a: 1, b: "b"} {a: 1, b: "b"}
+
+  assert $ eqRecord { a: 1, b: { c : "foo" }} {a: 1, b: { c: "foo" }}


### PR DESCRIPTION
This is just proposition to maybe integrate more of generic implementations of standard classes methods for records (with nested records).
My implementation for `EqRowList` doesn't modify input records and can be used to compare subrecords   too but the primary purpose behind this implementation is efficiency.
If you decide to merge this PR I think it would be good to rename this repository and probably modules (maybe to `Data.Record.Eq` etc.).